### PR TITLE
[Fix] Map Generator 수정 및 scroll 감도 수정

### DIFF
--- a/Assets/LDH/LDH_Prefabs/Map/MapCanvas.prefab
+++ b/Assets/LDH/LDH_Prefabs/Map/MapCanvas.prefab
@@ -278,7 +278,7 @@ RectTransform:
   m_Father: {fileID: 4881366600895706540}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0.9999772}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -441,7 +441,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 7318475727664078509}
   m_Direction: 2
   m_Value: 0
-  m_Size: 0.9999772
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:

--- a/Assets/LDH/LDH_Prefabs/Map/MapCanvas.prefab
+++ b/Assets/LDH/LDH_Prefabs/Map/MapCanvas.prefab
@@ -128,11 +128,11 @@ MonoBehaviour:
   m_Content: {fileID: 6933671001756618474}
   m_Horizontal: 0
   m_Vertical: 1
-  m_MovementType: 1
+  m_MovementType: 2
   m_Elasticity: 0.1
   m_Inertia: 1
   m_DecelerationRate: 0.135
-  m_ScrollSensitivity: 1
+  m_ScrollSensitivity: 10
   m_Viewport: {fileID: 8808974930477773682}
   m_HorizontalScrollbar: {fileID: 0}
   m_VerticalScrollbar: {fileID: 7389568502521389533}

--- a/Assets/LDH/LDH_Script/Map/MapConfig.cs
+++ b/Assets/LDH/LDH_Script/Map/MapConfig.cs
@@ -23,7 +23,7 @@ namespace Map
 
         
         [Header("Weights")]
-        public float BattleNodeWeight = 10.0f;
+        public float BattleNodeWeight = 0f;
         public float ShopNodeWeight = 2.5f;
         public float EventNodeWeight = 4.0f;
 

--- a/Assets/LDH/LDH_Script/Map/MapGenerator.cs
+++ b/Assets/LDH/LDH_Script/Map/MapGenerator.cs
@@ -60,15 +60,15 @@ namespace Map
             for (int j = 0; j < startingPoints.Count; j++)
             {
                 int currentJ = startingPoints[j];
-                for (int i = 1; i < _floors - 1; i++)
+                for (int i = 2; i < _floors - 2; i++) //3층부터 path 선정, 1~2층과 보스 이전층 ~ 보스층은 노드 1개로 고정처리
                 {
                     currentJ = SetUpConnection(i, currentJ);
                 }
             }
 
             //4. start Room, boss room setting
-            Node startNode = SetUpStartRoom();
-            Node bossNode = SetUpBossRoom();
+            Node startNode = SetUpStartAndFloorOne();
+            Node bossNode = SetUpBeforBossAndBoss();
             
             //5. 모든 path 탐색
             _allPath = GetAllPaths(startNode, bossNode);
@@ -202,43 +202,61 @@ namespace Map
 
 
         // - 시작 노드와 그 다음 floor와의 connection 설정
-        // - room type 설정
-        private Node SetUpStartRoom()
+        // - node type 설정
+        private Node SetUpStartAndFloorOne()
         {
             int middle = Mathf.FloorToInt(_mapWidth * 0.5f);
             Node startNode = _map[0][middle];
+            Node floorOneNode = _map[1][middle];
+            
+            //타입 배정
+            startNode.nodeType = NodeType.Battle;
+            floorOneNode.nodeType = NodeType.Shop;
+            
+            //startNode와 Floor 1 노드 연결
+            startNode.nextNodes.Add(floorOneNode);
 
+            //floor 1 과 floor 2 연결
             for (int j = 0; j < _mapWidth; j++)
             {
-                Node currentNode = _map[1][j];
+                Node currentNode = _map[2][j];
                 if (currentNode.HasConnections())
                 {
-                    startNode.nextNodes.Add(currentNode);
+                    floorOneNode.nextNodes.Add(currentNode);
                 }
             }
-
-            startNode.nodeType = NodeType.Battle;
+            
             return startNode;
         }
 
         //- 보스룸 이전 floor와 보스 룸 connection 설정
-        //- room type 설정
-        private Node SetUpBossRoom()
+        //- node type 설정
+        private Node SetUpBeforBossAndBoss()
         {
             int middle = Mathf.FloorToInt(_mapWidth * 0.5F);
             Node bossNode = _map[_floors - 1][middle];
-
+            Node beforeBossNode = _map[_floors - 2][middle];
+            
+            //타입 배정
+            bossNode.nodeType = NodeType.Boss;
+            beforeBossNode.nodeType = NodeType.Shop;
+            
+            //보스 이전 방과 보스 방 연결
+            beforeBossNode.nextNodes.Add(bossNode);
+            
+            
+            //floors - 3과 floors - 2 층 연결
             for (int j = 0; j < _mapWidth; j++)
             {
-                Node currentNode = _map[_floors - 2][j];
+                Node currentNode = _map[_floors - 3][j];
                 if (currentNode.HasConnections())
                 {
                     currentNode.nextNodes.Clear();
-                    currentNode.nextNodes.Add(bossNode);
+                    currentNode.nextNodes.Add(beforeBossNode);
                 }
             }
 
-            bossNode.nodeType = NodeType.Boss;
+         
 
             return bossNode;
         }

--- a/Assets/LDH/LDH_Script/Map/MapView.cs
+++ b/Assets/LDH/LDH_Script/Map/MapView.cs
@@ -34,7 +34,8 @@ namespace Map
 
         [Header("UI Map Settings")]
         [SerializeField] private ScrollRect scrollRectVertical;
-        [SerializeField] private float padding; // 맵 전체 좌+우/위+아래 여백
+        [SerializeField] private float widthPadding; // 맵 전체의 좌우 여백
+        [SerializeField] private float heightPadding; // 맵 전체의 상하 여백
         [SerializeField] private Vector2 backgroundPadding; // 배경 이미지 좌우 여백
         [SerializeField] private float backgroundPPUMultiplier = 1; // 배경 이미지 Pixels Per Unit 배율
         
@@ -116,7 +117,7 @@ namespace Map
             mapParent.transform.SetParent(firstParent.transform);
             mapParent.transform.localScale = Vector3.one;
             RectTransform mprt = mapParent.AddComponent<RectTransform>();
-            UILayout.Stretch(mprt, new Vector4(200,0,200,0));
+            UILayout.Stretch(mprt);
 
             
             //맵 전체 길이 계산해서 스크롤 영역(Content) 크기 설정하기
@@ -255,7 +256,7 @@ namespace Map
             RectTransform content = scrollRectVertical.content;
             Vector2 sizeDelta = content.sizeDelta;
 
-            float length = padding + Manager.Map.config.yGap * (Manager.Map.config.floors - 1);
+            float length = heightPadding + Manager.Map.config.yGap * (Manager.Map.config.floors - 1);
 
             sizeDelta.y = length;
 
@@ -299,7 +300,7 @@ namespace Map
             Vector2 offset = new Vector2(Manager.randomManager.RandFloat(0, 1), Manager.randomManager.RandFloat(0, 1)) *
                              Manager.Map.config.placementRandomness;
             
-            float x = (mapParentSize.x - padding) * ( (float)node.column / (Manager.Map.config.mapWidth - 1) - 0.5f);
+            float x = (mapParentSize.x - widthPadding) * ( (float)node.column / (Manager.Map.config.mapWidth - 1) - 0.5f);
             float y = (Manager.Map.config.yGap) * ((float)node.row - (Manager.Map.config.floors) / 2f + 0.5f);
 
             Vector2 localPos = new Vector2(x, y) + offset;

--- a/Assets/LDH/ScriptableObjects/MapConfig/MapConfig.asset
+++ b/Assets/LDH/ScriptableObjects/MapConfig/MapConfig.asset
@@ -24,6 +24,6 @@ MonoBehaviour:
   floors: 9
   mapWidth: 5
   paths: 4
-  BattleRoomWeight: 0
-  ShopRoomWeight: 2.5
-  EventRoomWeight: 4
+  BattleNodeWeight: 0
+  ShopNodeWeight: 2.5
+  EventNodeWeight: 4

--- a/Assets/Resources/Prefabs/MapManager.prefab
+++ b/Assets/Resources/Prefabs/MapManager.prefab
@@ -74,7 +74,8 @@ MonoBehaviour:
   linePointsCount: 10
   offsetFromNodes: 50
   scrollRectVertical: {fileID: 2384409123853657601}
-  padding: 400
+  widthPadding: 800
+  heightPadding: 400
   backgroundPadding: {x: 0, y: 0}
   backgroundPPUMultiplier: 1
 --- !u!114 &5785903751494116985


### PR DESCRIPTION
# 📌 Pull Request
---

## ✨ 작업 내용
기획팀 피드백에 따라 타입이 고정된 층은 노드를 1개만 생성해서 1개의 Path 만 갖도록 수정했습니다.
1층은 배틀 타입의 노드 1개, 2층은 상점 타입의 노드 1개, 보스 이전 층은 상점 타입의 노드 1개, 보스룸은 보스 타입의 노드 1개로 생성되게 했습니다.

이전에 맵이 랜더링되는 scroll rect의 감도를 따로 설정하지 않아 sensitivity를 10으로, movement type을 clamped로 변경했으며, 맵의 background다 화면 전체를 채우도록 수정했습니다.

맵 구현은 1차적으로 여기서 마무리하고 이후 기획에서 자세한 디자인이나 UI가 나온다면 수정하도록 하겠습니다.

## 💬 리뷰 요청사항 (선택)

---