### PR TITLE
[Feat] Lust, Glutton

### DIFF
--- a/Assets/CJH/CJH_Scripts/CJH_Manager/CardManager.cs
+++ b/Assets/CJH/CJH_Scripts/CJH_Manager/CardManager.cs
@@ -1,3 +1,4 @@
+using CardEnum;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -22,6 +23,10 @@ public class CardManager : MonoBehaviour
         if (selectedCards.Count >= 5) return;
 
         selectedCards.Add(card);
+
+        //  디버프 적용
+        var debuffType = card.debuff.debuffinfo;
+
 
         if (selectedCards.Count == 5)
         {
@@ -48,4 +53,30 @@ public class CardManager : MonoBehaviour
     }
 
     public void Reset() => selectedCards.Clear();
+
+    public MinorArcana GetRandomHandCard()
+    {
+        if (handCards.Count == 0) return default;
+        return handCards[UnityEngine.Random.Range(0, handCards.Count)];
+    }
+
+    public int CountDebuffedCardsInHand(CardDebuff debuffType)
+    {
+        int count = 0;
+        foreach (var card in handCards)
+        {
+            if (card.debuff.debuffinfo == debuffType)
+                count++;
+        }
+        return count;
+    }
+
+    public void DiscardAllHandCards()
+    {
+        foreach (var card in new List<MinorArcana>(handCards))
+        {
+            RemoveCard(card);
+            Debug.Log($"[CardManager] 카드 폐기됨: {card.CardName}");
+        }
+    }
 }

--- a/Assets/CJH/CJH_Scripts/Character/GluttonMonster.cs
+++ b/Assets/CJH/CJH_Scripts/Character/GluttonMonster.cs
@@ -1,0 +1,120 @@
+using CardEnum;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GluttonMonster : EnemyBase
+{
+    public static GluttonMonster Instance { get; private set; }
+
+    [SerializeField] private float basicRatio = 0.05f;
+    [SerializeField] private float heavyRatio = 0.15f;
+    [SerializeField] private float specialRatio = 0.10f;
+    [SerializeField] private float basicChance = 0.70f;
+
+    private int consecutiveBasic = 0;
+
+
+
+    private void Awake()
+    {
+        if (Instance == null) Instance = this;
+    }
+
+    public override void TakeTurn()
+    {
+        StartCoroutine(TurnRoutine());
+    }
+
+    private IEnumerator TurnRoutine()
+    {
+        // 조건부 행동: 손패에 부식 카드 4장 이상 → 즉사
+        int rustCount = CardManager.Instance.CountDebuffedCardsInHand(CardDebuff.Rust);
+        if (rustCount >= 4)
+        {
+            Debug.Log("[GluttonMonster] 부식 카드 4장 이상 → 패배 조건 발동");
+            TurnManager.Instance.GetPlayerController().TakeDamage(maxHP);
+            yield break;
+        }
+
+        float roll = Random.value;
+        if (roll < basicChance)
+        {
+            // 일반 패턴: 기본 or 강공격
+            if (consecutiveBasic < 2)
+                yield return BasicAttack();
+            else
+                yield return HeavyAttack();
+        }
+        else
+        {
+            // 특수 패턴 (특수공격 1/3, 특수행동 2/3)
+            if (Random.value < 0.33f)
+                yield return SpecialAttack();
+            else
+                yield return SpecialAction();
+        }
+
+        yield return null;
+    }
+
+    private IEnumerator BasicAttack()
+    {
+        Debug.Log("[GluttonMonster] 기본 공격: 5% 피해 + 부패 1장");
+        var player = TurnManager.Instance.GetPlayerController();
+        player.TakeDamage(Mathf.RoundToInt(maxHP * basicRatio));
+
+        var card = CardManager.Instance.GetRandomHandCard();
+        if (card != null)
+            player.GetComponent<CardController>().ApplyDebuff(card, CardDebuff.Corruption);
+
+        consecutiveBasic++;
+        yield return null;
+    }
+
+    private IEnumerator HeavyAttack()
+    {
+        Debug.Log("[GluttonMonster] 강공격: 15% 피해 + 부식 1장");
+        var player = TurnManager.Instance.GetPlayerController();
+        player.TakeDamage(Mathf.RoundToInt(maxHP * heavyRatio));
+
+        var card = CardManager.Instance.GetRandomHandCard();
+        if (card != null)
+            player.GetComponent<CardController>().ApplyDebuff(card, CardDebuff.Rust);
+
+        consecutiveBasic = 0;
+        yield return null;
+    }
+
+    private IEnumerator SpecialAttack()
+    {
+        Debug.Log("[GluttonMonster] 특수공격: 10% 피해 + 부패 2장");
+        var player = TurnManager.Instance.GetPlayerController();
+        player.TakeDamage(Mathf.RoundToInt(maxHP * specialRatio));
+
+        for (int i = 0; i < 2; i++)
+        {
+            var card = CardManager.Instance.GetRandomHandCard();
+            if (card != null)
+                player.GetComponent<CardController>().ApplyDebuff(card, CardDebuff.Corruption);
+        }
+        yield return null;
+    }
+
+    private IEnumerator SpecialAction()
+    {
+        Debug.Log("[GluttonMonster] 특수 행동: 피해 없음 + 부식1장, 부패1장");
+        var player = TurnManager.Instance.GetPlayerController();
+
+        var rustCard = CardManager.Instance.GetRandomHandCard();
+        if (rustCard != null)
+            player.GetComponent<CardController>().ApplyDebuff(rustCard, CardDebuff.Rust);
+
+        var corCard = CardManager.Instance.GetRandomHandCard();
+        if (corCard != null)
+            player.GetComponent<CardController>().ApplyDebuff(corCard, CardDebuff.Corruption);
+
+        yield return null;
+    }
+
+}

--- a/Assets/CJH/CJH_Scripts/Character/GluttonMonster.cs.meta
+++ b/Assets/CJH/CJH_Scripts/Character/GluttonMonster.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7924cfac485e19940a34e40befb2e039
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CJH/CJH_Scripts/Character/LustMonster.cs
+++ b/Assets/CJH/CJH_Scripts/Character/LustMonster.cs
@@ -1,0 +1,100 @@
+using CardEnum;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class LustMonster : EnemyBase
+{
+    public static LustMonster Instance { get; private set; }
+
+    [SerializeField] private int fatalStackThreshold = 5;
+    [SerializeField] private float temptChance = 0.6f;
+
+    private int lustStack = 0;
+    private const int stackMax = 10;
+
+    private void Awake()
+    {
+        if (Instance == null)
+            Instance = this;
+    }
+
+    public int LustStack => lustStack;
+
+    public void IncreaseLustStack(int amount)
+    {
+        lustStack = Mathf.Min(lustStack + amount, stackMax);
+        Debug.Log($"[LustMonster] 러스트 스택 증가 → 현재: {lustStack}");
+
+        if (lustStack >= fatalStackThreshold)
+        {
+            StartCoroutine(TriggerFatalAttack());
+        }
+    }
+
+    private IEnumerator TriggerFatalAttack()
+    {
+        Debug.Log($"[LustMonster] 스택 {lustStack} → 즉사기 발동!!");
+        TurnManager.Instance.GetPlayerController().TakeDamage(maxHP); // 즉사 처리
+        lustStack = 0;
+        yield return null;
+    }
+
+    public override void TakeTurn()
+    {
+        StartCoroutine(TurnRoutine());
+    }
+
+    private IEnumerator TurnRoutine()
+    {
+        Debug.Log("[LustMonster] 턴 시작");
+
+        // 1. 유혹 확률 판단
+        if (Random.value < temptChance)
+        {
+            yield return ExecuteTemptation();
+        }
+        else
+        {
+            yield return ExecutePunishment();
+        }
+
+        yield return null;
+    }
+
+    private IEnumerator ExecuteTemptation()
+    {
+        Debug.Log("[LustMonster] 유혹 공격: 5% 피해 + Rust 디버프 부여");
+        var player = TurnManager.Instance.GetPlayerController();
+        player.TakeDamage(Mathf.RoundToInt(maxHP * 0.05f));
+
+        var card = CardManager.Instance.GetRandomHandCard();
+        if (card != null)
+        {
+            // 연결한 이벤트들 작동
+            player.GetComponent<CardController>()
+                  .ApplyDebuff(card, CardDebuff.Rust);
+        }
+
+        yield return null;
+    }
+
+    private IEnumerator ExecutePunishment()
+    {
+        int rustedCount = CardManager.Instance.CountDebuffedCardsInHand(CardDebuff.Rust);
+
+        if (rustedCount >= 3)
+        {
+            Debug.Log("[LustMonster] 손패에 Rust 카드 3장 이상 → 전부 폐기 + 10% 피해!");
+
+            CardManager.Instance.DiscardAllHandCards();
+            TurnManager.Instance.GetPlayerController().TakeDamage(Mathf.RoundToInt(maxHP * 0.1f));
+        }
+        else
+        {
+            Debug.Log("[LustMonster] 손패의 Rust 카드 부족 → 아무 일도 일어나지 않음");
+        }
+
+        yield return null;
+    }
+}

--- a/Assets/CJH/CJH_Scripts/Character/LustMonster.cs.meta
+++ b/Assets/CJH/CJH_Scripts/Character/LustMonster.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b0942ae2e4d4c74449efe4ef1904ddf4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CJH/CJH_Scripts/DebuffDatabase.cs
+++ b/Assets/CJH/CJH_Scripts/DebuffDatabase.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using UnityEngine;
+using CardEnum;
+
+[CreateAssetMenu(menuName = "Database/DebuffDatabase")]
+public class DebuffDatabase : ScriptableObject
+{
+    public static DebuffDatabase Instance { get; private set; }
+
+    [System.Serializable]
+    public class Entry
+    {
+        public CardDebuff type;
+        public CardDebuffSO debuffSO;
+    }
+
+    [SerializeField] private List<Entry> entries;
+    private Dictionary<CardDebuff, CardDebuffSO> lookup = new();
+
+    private void OnEnable()
+    {
+        Instance = this;
+        lookup.Clear();
+        foreach (var entry in entries)
+        {
+            if (!lookup.ContainsKey(entry.type))
+                lookup[entry.type] = entry.debuffSO;
+        }
+    }
+
+    public CardDebuffSO GetDebuffSO(CardDebuff type)
+    {
+        lookup.TryGetValue(type, out var so);
+        return so;
+    }
+}

--- a/Assets/CJH/CJH_Scripts/DebuffDatabase.cs.meta
+++ b/Assets/CJH/CJH_Scripts/DebuffDatabase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 844e0615e007b77448e9512a66c0b616
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CJH/CJH_Scripts/DummyCardController.cs
+++ b/Assets/CJH/CJH_Scripts/DummyCardController.cs
@@ -1,0 +1,19 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DummyCardController : MonoBehaviour
+{
+    public static DummyCardController Instance { get; private set; }
+
+    private void Awake()
+    {
+        if (Instance == null) Instance = this;
+    }
+
+    public void AddPanelty(int amount)
+    {
+        Debug.Log($"[패널티 적용] 패널티 {amount}");
+    }
+
+}

--- a/Assets/CJH/CJH_Scripts/DummyCardController.cs.meta
+++ b/Assets/CJH/CJH_Scripts/DummyCardController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6495df60ac6b7ce4c94edc2322a0c84a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CSJ/Card/CardDeck/CardController.cs
+++ b/Assets/CSJ/Card/CardDeck/CardController.cs
@@ -624,6 +624,38 @@ public class CardController : MonoBehaviour
     #endregion
 
 
+    /// <summary>
+    /// 카드에 디버프를 걸고, 필요 시 몬스터 스택 증폭을 연결
+    /// </summary>
+    public void ApplyDebuff(MinorArcana card, CardDebuff type)
+    {
+        var so = DebuffDatabase.Instance.GetDebuffSO(type);
+        if (so == null) return;
 
+        // 1) 카드에 디버프 정보 세팅
+        card.debuff.DebuffToCard(type);
+        // 2) SO 구독
+        so.OnSubscribe(card, this);
+
+        // 3) Rust(유혹)일 경우 몬스터 스택 연결
+        if (so is CharmSO charm)
+        {
+            // 유혹량이 발생할 때마다 스택 증가시키도록 바인딩
+            charm.OnCharmCardUsed += amount =>
+                LustMonster.Instance.IncreaseLustStack(amount);
+        }
+    }
+
+    /// <summary>
+    /// 배틀 종료 시(혹은 카드 제거 시) 디버프 해제
+    /// </summary>
+    public void RemoveDebuff(MinorArcana card)
+    {
+        var type = card.debuff.debuffinfo;
+        var so = DebuffDatabase.Instance.GetDebuffSO(type);
+        if (so != null)
+            so.OnUnSubscribe(card, this);
+        card.debuff.DebuffToCard(CardDebuff.none);
+    }
 
 }

--- a/Assets/CSJ/Card/CardDeck/CardDeck.cs
+++ b/Assets/CSJ/Card/CardDeck/CardDeck.cs
@@ -26,6 +26,7 @@ public class CardDeck
     // 카드가 삭제될 때의 이벤트 (미사용)
     // public Action<MinorArcana> OnCardRemoved;
 
+
     public CardDeck(CsvTable csvTable)
     {
         _csvTable = csvTable;
@@ -153,11 +154,9 @@ public class CardDeck
         OnCardEnchanted?.Invoke(_card, _enchant.EnchantType);
     }
 
-    public void Debuff(MinorArcana _card, CardDebuffSO _debuff)
+    public void Debuff(MinorArcana card, CardDebuff debuffType)
     {
-        DebuffDic[_card] = _debuff;
-        _card.debuff.DebuffToCard(_debuff.DebuffType);
-        OnCardDebuffed?.Invoke(_card, _debuff.DebuffType);
+        OnCardDebuffed?.Invoke(card, debuffType);
     }
 
     public void DebuffClear(MinorArcana _card)

--- a/Assets/CSJ/Card/SO/Debuff/CharmSO.cs
+++ b/Assets/CSJ/Card/SO/Debuff/CharmSO.cs
@@ -10,22 +10,23 @@ public class CharmSO : CardDebuffSO
     public int charmAmount = 1;
     public Action<int> OnCharmCardUsed;
 
+    // 델리게이트 참조를 저장할 필드
+    private Action<MinorArcana> playHandler;
+
     public override void OnSubscribe(MinorArcana card, CardController controller)
     {
-        controller.OnCardSubmited += c =>
+        playHandler = c =>
         {
             if (c == card)
                 OnCardPlayed(c, controller);
         };
+        controller.OnCardSubmited += playHandler;
     }
 
     public override void OnUnSubscribe(MinorArcana card, CardController controller)
     {
-        controller.OnCardSubmited -= c =>
-        {
-            if (c == card)
-                OnCardPlayed(c, controller);
-        };
+        if (playHandler != null)
+            controller.OnCardSubmited -= playHandler;
     }
 
     public override void OnCardPlayed(MinorArcana card, CardController controller)

--- a/Assets/CSJ/Card/SO/Debuff/CorruptionSO.cs
+++ b/Assets/CSJ/Card/SO/Debuff/CorruptionSO.cs
@@ -6,25 +6,33 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "Corruption", menuName = "Cards/Debuff/Corruption")]
 public class CorruptionSO : CardDebuffSO
 {
-    private bool IsUsed;
-    [SerializeField] RustSO rust;
+    private bool isUsedThisTurn;
+    [SerializeField] private CardDebuff rustDebuff; // 부식 디버프 종류
+
     public override void OnSubscribe(MinorArcana card, CardController controller)
     {
-        IsUsed = false;
+        isUsedThisTurn = false;
         base.OnSubscribe(card, controller);
     }
 
     public override void OnCardPlayed(MinorArcana card, CardController controller)
     {
-        IsUsed = true;
+        isUsedThisTurn = true;
     }
 
     public override void OnTurnEnd(MinorArcana card, CardController controller)
     {
-        if (!IsUsed)
+        if (!isUsedThisTurn)
         {
-            controller.Deck.Debuff(card, rust);
+            Debug.Log($"[부패] {card.CardName} 사용되지 않음 → Rust로 부식됨");
+            controller.Deck.Debuff(card, rustDebuff); // RustSO 부여
         }
-        else controller.Deck.DebuffClear(card);
+        else
+        {
+            Debug.Log($"[부패] {card.CardName} 사용됨 → 부패 해제");
+            controller.Deck.DebuffClear(card);
+        }
+
+        isUsedThisTurn = false;
     }
 }

--- a/Assets/CSJ/Card/SO/Debuff/RustSO.cs
+++ b/Assets/CSJ/Card/SO/Debuff/RustSO.cs
@@ -1,4 +1,5 @@
 using CardEnum;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -6,11 +7,26 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "Rust", menuName = "Cards/Debuff/Rust")]
 public class RustSO : CardDebuffSO
 {
-    [SerializeField] private int panelty = 50;
+    [SerializeField] private int penalty = 50;
+    private Action<MinorArcana> playHandler;
 
-    public override void OnCardPlayed(MinorArcana card, CardController controller)
+    public override void OnSubscribe(MinorArcana card, CardController controller)
     {
-        controller.AddPanelty(panelty);
+        playHandler = c =>
+        {
+            if (c == card)
+            {
+                Debug.Log($"[부식] {card.CardName} 사용 → 데미지 {penalty}만큼 감소");
+                controller.AddPanelty(penalty);
+                // 부식 효과는 사라지지 않고 계속 유지된다
+            }
+        };
+        controller.OnCardSubmited += playHandler;
     }
 
+    public override void OnUnSubscribe(MinorArcana card, CardController controller)
+    {
+        if (playHandler != null)
+            controller.OnCardSubmited -= playHandler;
+    }
 }


### PR DESCRIPTION
러스트 와 글러트디 구현

# 📌 Pull Request
---

## ✨ 작업 내용
- Task 작업 내용 (To-Do) 진행도 체크 및 작업한 내용, 변경 사항 간략히 설명
몬스터 색욕 러스트와 식욕 글러트디가 구현되었습니다.
 몬스터 패턴 상태는 원본 스크립트를 가지고 있습니다. CardDeck 스크립트에 디버프 함수와 디버프 클리어 메서드를 추가하였습니다.
러스트의 유혹 경우 CardController에서 스택을 관리합니다. 따라서 러스트몬스터 스크립트에서는 ApplyDebuff를 호출하여 연결된 이벤트들을 작동시킵니다.
동작 순서는 몬스터가 유혹 효과를 부여하면 CharmSO에서 OnCharmCardUsed를 호출합니다. LustMonster스크립트 안에 있는
 IncreaseLustStack에 스택을 증가시킵니다.


## 💬 리뷰 요청사항 (선택)
- 리뷰어가 집중해서 봐줬으면 하는 코드/구조/로직이 있다면 작성

---