### PR TITLE
[Fix] 이벤트 오류 수정

### DIFF
--- a/Assets/LDH/LDH_Scene/InGameShop.unity
+++ b/Assets/LDH/LDH_Scene/InGameShop.unity
@@ -3288,7 +3288,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 717261ac69a9424ca1bd4af9143d504f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _itemInfo: {fileID: 878028838}
+  _itemInfo: {fileID: 2021479068}
   _itemName: {fileID: 878028838}
   _itemPrice: {fileID: 1270201628}
   _purchaseButton: {fileID: 1358400816}
@@ -5272,7 +5272,7 @@ GameObject:
   - component: {fileID: 2021479069}
   - component: {fileID: 2021479068}
   m_Layer: 5
-  m_Name: Text (TMP) (1)
+  m_Name: Info
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/LDH/LDH_Script/Event/EventData/SubEffectScripts/AttackBoostEffect.cs
+++ b/Assets/LDH/LDH_Script/Event/EventData/SubEffectScripts/AttackBoostEffect.cs
@@ -1,15 +1,19 @@
+using System;
+
 namespace Event
 {
     public class AttackBoostEffect : SubEffect
     {
         public AttackBoostEffect(int value, int? durationTurns) : base(SubEffectType.AttackBoost, value, durationTurns) { }
 
-        public override void ApplyEffect()
+        public override void ApplyEffect(Action onComplete)
         {
-            base.ApplyEffect();
+            base.ApplyEffect(null);
             //todo: player attack bost 적용 테스트 필요 
             var player = TurnManager.Instance.GetPlayerController();
             player.AddAttackBuff(Value, DurationTurns??1);
+            
+            onComplete?.Invoke();
         }
     }
 }

--- a/Assets/LDH/LDH_Script/Event/EventData/SubEffectScripts/GoldChangeEffect.cs
+++ b/Assets/LDH/LDH_Script/Event/EventData/SubEffectScripts/GoldChangeEffect.cs
@@ -1,4 +1,5 @@
 using Managers;
+using System;
 
 namespace Event
 {
@@ -6,10 +7,11 @@ namespace Event
     {
         public GoldGainEffect(int value) : base(SubEffectType.ResourceGain, value) { }
 
-        public override void ApplyEffect()
+        public override void ApplyEffect(Action onComplete)
         {
-            base.ApplyEffect();
+            base.ApplyEffect(null);
             Manager.GameState.AddGold(Value);
+            onComplete?.Invoke();
         }
     }
 }

--- a/Assets/LDH/LDH_Script/Event/EventData/SubEffectScripts/GoldLossEffect.cs
+++ b/Assets/LDH/LDH_Script/Event/EventData/SubEffectScripts/GoldLossEffect.cs
@@ -1,15 +1,17 @@
 using Managers;
+using System;
 
 namespace Event
 {
     public class GoldLossEffect : SubEffect
     {
         public GoldLossEffect(int value) : base(SubEffectType.ResourceGain, value) { }
-        public override void ApplyEffect()
+        public override void ApplyEffect(Action onComplete)
         {
-            base.ApplyEffect();
+            base.ApplyEffect(null);
             
             Manager.GameState.AddGold(-Value);
+            onComplete?.Invoke();
         }
     }
 }

--- a/Assets/LDH/LDH_Script/Event/EventData/SubEffectScripts/NoEffect.cs
+++ b/Assets/LDH/LDH_Script/Event/EventData/SubEffectScripts/NoEffect.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace Event
@@ -6,10 +7,11 @@ namespace Event
     {
         public NoEffect(SubEffectType subEffectType = SubEffectType.NoEffect, int value = 0, int? durationTurns = null) : base(subEffectType, value, durationTurns) { }
 
-        public override void ApplyEffect()
+        public override void ApplyEffect(Action onComplete)
         {
-            base.ApplyEffect();
+            base.ApplyEffect(null);
             Debug.Log("아무런 효과가 없음");
+            onComplete?.Invoke();
         }
     }
 }

--- a/Assets/LDH/LDH_Script/Event/EventData/SubEffectScripts/ObtainCardEffect.cs
+++ b/Assets/LDH/LDH_Script/Event/EventData/SubEffectScripts/ObtainCardEffect.cs
@@ -1,6 +1,7 @@
 using InGameShop;
 using Item;
 using Managers;
+using System;
 using System.Collections.Generic;
 
 namespace Event
@@ -10,15 +11,17 @@ namespace Event
         public ObtainCardEffect(int value) : base(SubEffectType.ObtainEnhancedCard, value)
         { }
 
-        public override void ApplyEffect()
+        public override void ApplyEffect(Action onComplete)
         {
-            base.ApplyEffect();
+            base.ApplyEffect(null);
             List<GameItem> enchantItems = Manager.Data.GameItemDB.PickUniqeItemRandomByType(Value, ItemType.Card);
             
             foreach (EnchantItem enchantItem in enchantItems)
             {
                 Manager.GameState.AddCardItem(enchantItem);
             }
+            
+            onComplete?.Invoke();
         }
     }
 }


### PR DESCRIPTION
이벤트에서 아이템을 획득했을때, 슬롯이 모두 차 있는 경우 아이템 제거가 이루어지고 -> 보상 아이템을 획득하고 -> 맵이 떠야 하는데
맵이 먼저 떠버리는 오류가 발생해서 적용 순서를 변경했습니다.